### PR TITLE
Fix save_dir path in `run_eval.py` 

### DIFF
--- a/run_eval.py
+++ b/run_eval.py
@@ -114,7 +114,7 @@ def main(args):
     for eval_set, data_loader in zip(args.eval_sets, data_loaders):
         for scale in args.eval_scales:
             border_crop = scale + 6 if 'DIV2K' in eval_set else scale
-            save_dir = (Path(args.save_dir) / ('ours_' + eval_set + '_' + args.backbone) / str(scale)) \
+            save_dir = (Path(args.save_dir) / ('ours_' + eval_set + '_' + backbone) / str(scale)) \
                 if args.save_dir else None
 
             metrics = evaluate(data_loader, model, params, scale, border_crop,


### PR DESCRIPTION
Correct line 117 in run_eval.py

This PR corrects the save_dir path construction by replacing args.backbone with backbone, which is loaded from the pickle file. Previously, the script was incorrectly attempting to access args.backbone, which does not exist.

Before:
```python
save_dir = (Path(args.save_dir) / ('ours_' + eval_set + '_' + args.backbone) / str(scale))
```

After:
```python
save_dir = (Path(args.save_dir) / ('ours_' + eval_set + '_' + backbone) / str(scale))
```

